### PR TITLE
feat: reverse-proxy for a second domain #10

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,3 @@
-DOMAIN=cloud.example.pw
-EMAIL=user@example.pw
+DOMAIN_1=domain1.example.pw
+DOMAIN_2=domain2.example.pw
+EMAIL=ai@contributor.pw

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,9 +23,28 @@ jobs:
           # Флаг --delete удалит старые файлы, если вы их переименовали или удалили.
           sudo rsync -av --delete ${{ github.workspace }}/ /opt/actions-runner/apps/relaxy/ --exclude 'data' --exclude '.git'
 
+      - name: Ensure second-domain TLS certificate
+        env:
+          EMAIL: ${{ secrets.EMAIL }}
+          DOMAIN_2: ${{ secrets.DOMAIN_2 }}
+        run: |
+          # Переходим в постоянную папку проекта
+          cd /opt/actions-runner/apps/relaxy
+
+          # Идемпотентный выпуск сертификата для DOMAIN_2 ДО пересоздания nginx:
+          # уже работающий nginx отдаёт acme-challenge для любого хоста через
+          # default :80-сервер, поэтому challenge проходит без блоков DOMAIN_2.
+          # --keep-until-expiring делает повторные пуши no-op (лимиты LE не задеваем),
+          # но гарантирует наличие cert-файлов до того, как :443-блок их потребует.
+          sudo -E docker compose -f docker-compose.yml run --rm certbot \
+            certonly --webroot --webroot-path=/var/www/certbot \
+            --email "$EMAIL" -d "$DOMAIN_2" \
+            --agree-tos --no-eff-email --keep-until-expiring --non-interactive
+
       - name: Deploy services from permanent directory
         env:
-          DOMAIN: ${{ secrets.DOMAIN }}
+          DOMAIN_1: ${{ secrets.DOMAIN_1 }}
+          DOMAIN_2: ${{ secrets.DOMAIN_2 }}
           EMAIL: ${{ secrets.EMAIL }}
         run: |
           # Переходим в постоянную папку проекта

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@
 
 В вашем репозитории на GitHub перейдите в `Settings` > `Secrets and variables` > `Actions` и создайте два секрета:
 
-- `DOMAIN`: Ваше доменное имя (например, `cloud.contributor.pw`).
+- `DOMAIN_1`: Основной домен (например, `domain1.example.pw`).
+- `DOMAIN_2`: Второй домен (например, `domain2.example.pw`).
 - `EMAIL`: Ваш email для уведомлений от Let's Encrypt.
 
 ### Шаг 2: Создание внешней сети Docker
@@ -151,3 +152,20 @@ openssl s_client -connect ВАШ_ДОМЕН:443 -servername ВАШ_ДОМЕН 2>
 1. **Настройте ваше приложение**: В `docker-compose.yml` вашего приложения подключите его к сети `net`.
 2. **Добавьте location в Nginx**: Откройте `nginx.conf.template` и добавьте новый `location`.
 3. **Сделайте `git push`**. GitHub Actions автоматически применит новую конфигурацию Nginx.
+
+## 🌐 Второй домен (`DOMAIN_2`)
+
+Второй домен раздаётся через тот же фронтовый nginx. relaxy остаётся чистым
+прокси: **статику, `.htpasswd` и basic auth держит отдельный апстрим-сервис
+`site-2`** (свой контейнер, подключённый к сети `net`), а фронтовый nginx только
+терминирует TLS и проксирует.
+
+- Server-блоки для `$DOMAIN_2` заданы в `nginx.conf.template`; envsubst
+  подставляет и `$DOMAIN_1`, и `$DOMAIN_2`.
+- Домен задаётся секретом `DOMAIN_2` (см. Шаг 1).
+- **Сертификат выпускается автоматически в CI** — шаг `Ensure second-domain TLS
+  certificate` в `deploy.yml` идемпотентен (`--keep-until-expiring`), поэтому
+  повторные пуши не задевают лимиты Let's Encrypt. Ручной шаг не нужен.
+- Обновление сертификата покрыто общим cron: `certbot renew` обновляет все домены.
+
+DNS: A-запись второго домена должна указывать на IP сервера.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,13 @@ services:
       - '80:80'
       - '443:443'
     environment:
-      - DOMAIN
+      - DOMAIN_1
+      - DOMAIN_2
     volumes:
       - ./nginx.conf.template:/etc/nginx/templates/default.conf.template
       - ./data/certbot/conf:/etc/letsencrypt
       - ./data/certbot/www:/var/www/certbot
-    command: /bin/sh -c "envsubst '$$DOMAIN' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+    command: /bin/sh -c "envsubst '$$DOMAIN_1 $$DOMAIN_2' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
     networks:
       - net
     healthcheck:

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name $DOMAIN;
+    server_name $DOMAIN_1;
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
@@ -13,10 +13,10 @@ server {
 
 server {
     listen 443 ssl;
-    server_name $DOMAIN;
+    server_name $DOMAIN_1;
 
-    ssl_certificate /etc/letsencrypt/live/$DOMAIN/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/$DOMAIN/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/$DOMAIN_1/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$DOMAIN_1/privkey.pem;
 
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
@@ -31,5 +31,39 @@ server {
 
     location / {
         return 200 'OK';
+    }
+}
+
+server {
+    listen 80;
+    server_name $DOMAIN_2;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name $DOMAIN_2;
+
+    ssl_certificate /etc/letsencrypt/live/$DOMAIN_2/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$DOMAIN_2/privkey.pem;
+
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    # Статику, .htpasswd и basic auth держит сам апстрим-сервис site-2
+    # (отдельный контейнер в сети net). relaxy только терминирует TLS и проксирует.
+    location / {
+        proxy_pass http://site-2;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }


### PR DESCRIPTION
Closes #10

## Что делает

Раздаёт второй домен (`DOMAIN_2`) через фронтовый nginx relaxy: TLS-терминация + проксирование. relaxy остаётся **чистым прокси** — статику, `.htpasswd` и basic auth держит отдельный апстрим-сервис `site-2` (свой контейнер в сети `net`), внутрь relaxy ничего не кладём.

Отклонено от исходного предложения в issue: НЕ добавляем апстрим в `docker-compose.yml` relaxy и НЕ храним статику/`.htpasswd` в `data/`. Причина: relaxy по своей архитектуре только проксирует внешние сервисы, сохраняем эту развязку.

## Изменения

- `nginx.conf.template` — server-блоки для `$DOMAIN_2`: `:80` (acme-challenge + redirect), `:443 ssl` → `proxy_pass http://site-2` (без auth_basic — авторизация на стороне `site-2`).
- `docker-compose.yml` — envsubst расширен до `$DOMAIN_1 $DOMAIN_2`.
- Переименование `DOMAIN` → `DOMAIN_1` для симметрии с `DOMAIN_2`.
- `deploy.yml` — идемпотентный шаг выпуска TLS-сертификата второго домена в CI (`--keep-until-expiring`, повторные пуши не задевают лимиты Let's Encrypt). Выполняется до пересоздания nginx, пока старый nginx отдаёт acme-challenge через default `:80`-сервер.
- Домены не хранятся в исходниках — только в секретах (`DOMAIN_1`, `DOMAIN_2`); в коде/README нейтральные плейсхолдеры.
- `.env.sample`, `README.md` — обновлены.

## Секреты

`DOMAIN_1` и `DOMAIN_2` уже заведены в репозитории. Старый секрет `DOMAIN` после мержа можно удалить (заменён на `DOMAIN_1`).

Renew покрыт общим cron (`certbot renew` обновляет все домены). Сам апстрим `site-2` деплоится отдельно.
